### PR TITLE
Fix python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 ccxt.egg-info/
 tmp/
 *.pyc
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - '2.7'
+  - '3.4'
+  - '3.5'
+  - '3.6'
+install:
+  - pip install tox
+script: tox

--- a/ccxt/__init__.py
+++ b/ccxt/__init__.py
@@ -96,7 +96,7 @@ class Market (object):
         try:
             handler = _urllib.HTTPHandler if url.startswith ('http://') else _urllib.HTTPSHandler
             opener = _urllib.build_opener (handler)
-            response = opener.open (request, timeout = self.timeout).read ()
+            response = opener.open (request, timeout = self.timeout).read ().decode('utf-8')
             return json.loads (response)
         except _urllib.HTTPError as e:
             try: 

--- a/ccxt/__init__.py
+++ b/ccxt/__init__.py
@@ -21,6 +21,11 @@ except ImportError:
     import urllib  as _urlencode         # Python 2
     import urllib2 as _urllib
 
+try:
+  basestring # Python 3
+except NameError:
+  basestring = str # Python 2
+
 class Market (object):
 
     id        = None
@@ -36,8 +41,8 @@ class Market (object):
             setattr (self, key, config[key])
 
         if self.api:
-            for apiType, methods in self.api.iteritems ():
-                for method, urls in methods.iteritems ():                    
+            for apiType, methods in self.api.items ():
+                for method, urls in methods.items ():
                     for url in urls:
                         url = url.strip ()
                         splitPath = re.compile ('[^a-zA-Z0-9]').split (url)
@@ -96,7 +101,6 @@ class Market (object):
         except _urllib.HTTPError as e:
             try: 
                 text = e.fp.read ()
-                m = re.search ('(cloudflare)', text, flags = re.IGNORECASE)
                 if re.search ('(cloudflare)', text, flags = re.IGNORECASE):
                     error = 'DDoS protection by Cloudflare'
                     print (self.id, method, url, e.code, e.msg, error)
@@ -289,7 +293,7 @@ class Market (object):
         return self.fetch_products ()
 
     def product (self, product):
-        isString = type (product) in [ str, unicode ]
+        isString = isinstance (product, basestring)
         if isString and self.products and (product in self.products):
             return self.products [product]
         return product
@@ -2336,8 +2340,7 @@ class btcchina (Market):
         })
         result = []
         keys = products.keys ()
-        for p in range (0, len (keys)):
-            key = keys[p]
+        for key in keys:
             product = products[key]
             parts = key.split ('_')
             id = parts[1]

--- a/test.py
+++ b/test.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 
 import ccxt
-import sys
 import time
 
 verbose = False
@@ -77,11 +76,11 @@ def test_market (market):
 	products = market.load_products ()
 	# print (market.id, 'products', products)
 
-	keys = products.keys ()
+	keys = list(products.keys ())
 	print (market.id , len (keys), 'symbols', keys)
 	# time.sleep (delay)
 
-	symbol = products.keys ()[0]
+	symbol = keys[0]
 	for s in ['BTC/USD', 'BTC/CNY', 'BTC/ETH', 'ETH/BTC', 'BTC/JPY']:
 		if s in keys:
 			symbol = s

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = python
+skipsdist = True
+
+[testenv]
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}
+commands = python test.py


### PR DESCRIPTION
This PR fixes a couple python 3 compatibility issues I ran into, and adds some lightweight testing to try and help catch regressions in the future.

   - added a `tox` config for ensuring that `test.py` runs all the way through
   - added a `.travis.yml` that runs `tox` against a bunch of versions of python

If you guys go and enable travis-ci for the repository new pull requests and commits to master will run tests. See https://github.com/gnmerritt/ccxt/pull/1 for example of what that looks like