### PR TITLE
flake8 is installed by tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 - sudo dpkg -i pandoc-1.19.2.1-1-amd64.deb
 - python3 --version
 - pip3 --version
-- pip3 install tox flake8
+- pip3 install --upgrade tox
 script:
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm config set git-tag-version=false && NPM_VERSION=$(npm version patch); fi
 - npm run build


### PR DESCRIPTION
no need to specify qa dependencies in travis config