### PR TITLE
mktime parameters depend on PHP version

### DIFF
--- a/ccxt.php
+++ b/ccxt.php
@@ -373,7 +373,14 @@ class Exchange {
         // $sign = intval ($sign . '1');
         // $hours = (intval ($hours) or 0) * $sign;
         // $minutes = (intval ($minutes) or 0) * $sign;
-        $t = mktime ($h, $m, $s, $mm, $dd, $yyyy, 0);
+        
+        // is_dst parameter has been removed in PHP 7.0.0.
+        // http://php.net/manual/en/function.mktime.php
+        if(version_compare(PHP_VERSION, '7.0.0', '>=')){
+            $t = mktime ($h, $m, $s, $mm, $dd, $yyyy);
+        }else{
+            $t = mktime ($h, $m, $s, $mm, $dd, $yyyy, 0);
+        }
         $t += $hours * 3600 + $minutes * 60;
         $t *= 1000;
         return $t;


### PR DESCRIPTION
is_dst
This parameter can be set to 1 if the time is during daylight savings time (DST), 0 if it is not, or -1 (the default) if it is unknown whether the time is within daylight savings time or not. If it's unknown, PHP tries to figure it out itself. This can cause unexpected (but not incorrect) results. Some times are invalid if DST is enabled on the system PHP is running on or is_dst is set to 1. If DST is enabled in e.g. 2:00, all times between 2:00 and 3:00 are invalid and mktime() returns an undefined (usually negative) value. Some systems (e.g. Solaris 8) enable DST at midnight so time 0:30 of the day when DST is enabled is evaluated as 23:30 of the previous day.

Note:
As of PHP 5.1.0, this parameter became deprecated. As a result, the new timezone handling features should be used instead.
Note:
This parameter has been removed in PHP 7.0.0.