### PR TITLE
Fixed bitflyer request using query parameters

### DIFF
--- a/ccxt.js
+++ b/ccxt.js
@@ -3044,11 +3044,12 @@ var bitflyer = {
         if (api == 'private')
             request += 'me/';
         request += path;
-        let url = this.urls['api'] + request;
-        if (api == 'public') {
+        if (method == 'GET') {
             if (Object.keys (params).length)
-                url += '?' + this.urlencode (params);
-        } else {
+                request += '?' + this.urlencode (params);
+        }
+        let url = this.urls['api'] + request;
+        if (api == 'private') {
             let nonce = this.nonce ().toString ();
             body = this.json (params);
             let auth = [ nonce, method, request, body ].join ('');


### PR DESCRIPTION
Fixed that Bitflyer api using query parameter is unsupported 
like `GET /v1/me/getpositions`

Doc: https://lightning.bitflyer.jp/docs?lang=en