### PR TITLE
Cryptopia order books fixed false parsing

### DIFF
--- a/ccxt/exchanges.py
+++ b/ccxt/exchanges.py
@@ -8629,7 +8629,7 @@ class cryptopia (Exchange):
             'id': self.market_id(market),
         }, params))
         orderbook = response['Data']
-        return self.parse_order_book(orderbook, None, 'Buy', 'Sell', 'Price', 'Total')
+        return self.parse_order_book(orderbook, None, 'Buy', 'Sell', 'Price', 'Volume')
 
     def parse_ticker(self, ticker, market):
         timestamp = self.milliseconds()


### PR DESCRIPTION
Parsing order books from Cryptopia was partially wrong, 'Total' in the order books from Cryptopia API was representing the total value in base currency and not the volume that it was supposed to.  So if we take CHC/BTC market for an example, price would be parsed ok but the amount would be represented in BTC amount (base currency)  and not in CHC amount.