### PR TITLE
fix coincheck async request error

### DIFF
--- a/ccxt.js
+++ b/ccxt.js
@@ -8527,7 +8527,6 @@ var coincheck = {
             let auth = nonce + url + (body || '');
             headers = {
                 'Content-Type': 'application/x-www-form-urlencoded',
-                'Content-Length': length,
                 'ACCESS-KEY': this.apiKey,
                 'ACCESS-NONCE': nonce,
                 'ACCESS-SIGNATURE': this.hmac (this.encode (auth), this.encode (this.secret)),


### PR DESCRIPTION
[Issue]
I found a HTTP header error when I try to order for coincheck with asynchronous function.

[How to fix]
`Content-Length` attribute is not necessary for HTTP header when requesting coincheck.

[error log]

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-26863c45f7ab> in <module>()
     19 loop = asyncio.get_event_loop()
     20 tasks =  buy_coincheck() ,  sell_coincheck() 
---> 21 result1, result2 = loop.run_until_complete(asyncio.gather(*tasks)) 

/Users/take/.pyenv/versions/anaconda3-4.1.0/lib/python3.5/asyncio/base_events.py in run_until_complete(self, future)
    335             raise RuntimeError('Event loop stopped before Future completed.')
    336 
--> 337         return future.result()
    338 
    339     def stop(self):

/Users/take/.pyenv/versions/anaconda3-4.1.0/lib/python3.5/asyncio/futures.py in result(self)
    272             self._tb_logger = None
    273         if self._exception is not None:
--> 274             raise self._exception
    275         return self._result
    276 

/Users/take/.pyenv/versions/anaconda3-4.1.0/lib/python3.5/asyncio/tasks.py in _step(***failed resolving arguments***)
    237                 # We use the `send` method directly, because coroutines
    238                 # don't have `__iter__` and `__next__` methods.
--> 239                 result = coro.send(None)
    240             else:
    241                 result = coro.throw(exc)

<ipython-input-2-26863c45f7ab> in buy_coincheck()
      9     print("buy_coincheck")
     10     buy_cc=cc.client.createMarketBuyOrder('BTC/JPY', 391010 * MIN_ORDER_SIZE)
---> 11     return await buy_cc
     12 
     13 

/Users/take/.pyenv/versions/anaconda3-4.1.0/lib/python3.5/site-packages/ccxt/async/exchange.py in createMarketBuyOrder(self, market, amount, params)
    197 
    198     async def createMarketBuyOrder(self, market, amount, params={}):
--> 199         return await self.create_market_buy_order(market, amount, params)
    200 
    201     async def createMarketSellOrder(self, market, amount, params={}):

/Users/take/.pyenv/versions/anaconda3-4.1.0/lib/python3.5/site-packages/ccxt/async/exchange.py in create_market_buy_order(self, market, amount, params)
    185 
    186     async def create_market_buy_order(self, market, amount, params={}):
--> 187         return await self.create_order(market, 'market', 'buy', amount, None, params)
    188 
    189     async def create_market_sell_order(self, market, amount, params={}):

/Users/take/.pyenv/versions/anaconda3-4.1.0/lib/python3.5/site-packages/ccxt/async/exchanges.py in create_order(self, market, type, side, amount, price, params)
   6276             order['rate'] = price
   6277             order['amount'] = amount
-> 6278         response = await self.privatePostExchangeOrders(self.extend(order, params))
   6279         return {
   6280             'info': response,

/Users/take/.pyenv/versions/anaconda3-4.1.0/lib/python3.5/site-packages/ccxt/async/exchanges.py in request(self, path, api, method, params, headers, body)
   6307                 'ACCESS-SIGNATURE': self.hmac(self.encode(auth), self.encode(self.secret)),
   6308             }
-> 6309         response = await self.fetch(url, method, headers, body)
   6310         if api == 'public':
   6311             return response

/Users/take/.pyenv/versions/anaconda3-4.1.0/lib/python3.5/site-packages/ccxt/async/exchange.py in fetch(self, url, method, headers, body)
    106         print(headers)
    107         session_method = getattr(self.aiohttp_session, method.lower())
--> 108         async with session_method(url, data=body or None, headers=headers, timeout=(self.timeout / 1000)) as response:
    109             text = await response.text()
    110             error = None

/Users/take/.pyenv/versions/anaconda3-4.1.0/lib/python3.5/site-packages/aiohttp/client.py in __aenter__(self)
    601         @asyncio.coroutine
    602         def __aenter__(self):
--> 603             self._resp = yield from self._coro
    604             return self._resp
    605 

/Users/take/.pyenv/versions/anaconda3-4.1.0/lib/python3.5/site-packages/aiohttp/client.py in _request(self, method, url, params, data, json, headers, skip_auto_headers, auth, allow_redirects, max_redirects, encoding, compress, chunked, expect100, read_until_eof, proxy, proxy_auth, timeout)
    237                     conn.writer.set_tcp_nodelay(True)
    238                     try:
--> 239                         resp = req.send(conn)
    240                         try:
    241                             yield from resp.start(conn, read_until_eof)

/Users/take/.pyenv/versions/anaconda3-4.1.0/lib/python3.5/site-packages/aiohttp/client_reqrep.py in send(self, conn)
    399         status_line = '{0} {1} HTTP/{2[0]}.{2[1]}\r\n'.format(
    400             self.method, path, self.version)
--> 401         writer.write_headers(status_line, self.headers)
    402 
    403         self._writer = helpers.ensure_future(

/Users/take/.pyenv/versions/anaconda3-4.1.0/lib/python3.5/site-packages/aiohttp/http_writer.py in write_headers(self, status_line, headers, SEP, END)
    248         # status + headers
    249         headers = status_line + ''.join(
--> 250             [k + SEP + v + END for k, v in headers.items()])
    251         headers = headers.encode('utf-8') + b'\r\n'
    252 

/Users/take/.pyenv/versions/anaconda3-4.1.0/lib/python3.5/site-packages/aiohttp/http_writer.py in <listcomp>(.0)
    248         # status + headers
    249         headers = status_line + ''.join(
--> 250             [k + SEP + v + END for k, v in headers.items()])
    251         headers = headers.encode('utf-8') + b'\r\n'
    252 

TypeError: Can't convert 'int' object to str implicitly
```