### PR TITLE
fix asynchronous method in bitflyer

### DIFF
--- a/ccxt.js
+++ b/ccxt.js
@@ -3059,7 +3059,7 @@ var bitflyer = {
                 'Content-Type': 'application/json',
             };
         }
-        return this.fetch (url, method, headers, body);
+        return await this.fetch (url, method, headers, body);
     },
 }
 


### PR DESCRIPTION
'await' is necessary when using asynchronous processing in bitflyer

I fixed because of getting the following error

```python

bitflyer = ccxt.bitflyer({})
loop = asyncio.get_event_loop()
a = loop.run_until_complete(bitflyer.fetchTicker('FX_BTC_JPY'))
print(a)
loop.close()

```


```
Traceback (most recent call last):
  File "asynctest.py", line 24, in <module>
    a = loop.run_until_complete(bitflyer.fetchTicker('FX_BTC_JPY'))
  File "/Users/taish/anaconda3/lib/python3.6/asyncio/base_events.py", line 466, in run_until_complete
    return future.result()
  File "/Users/taish/anaconda3/lib/python3.6/site-packages/ccxt/async/exchange.py", line 181, in fetchTicker
    return await self.fetch_ticker(symbol)
  File "/Users/taish/anaconda3/lib/python3.6/site-packages/ccxt/async/exchanges.py", line 2301, in fetch_ticker
    await self.load_markets()
  File "/Users/taish/anaconda3/lib/python3.6/site-packages/ccxt/async/exchange.py", line 143, in load_markets
    markets = await self.fetch_markets()
  File "/Users/taish/anaconda3/lib/python3.6/site-packages/ccxt/async/exchanges.py", line 2253, in fetch_markets
    for p in range(0, len(markets)):
TypeError: object of type 'coroutine' has no len()
```