### PR TITLE
change Cyrillic "С" to latin "C" to avoid problem

### DIFF
--- a/js/okex3.js
+++ b/js/okex3.js
@@ -3274,8 +3274,8 @@ module.exports = class okex3 extends Exchange {
             const market = this.market (code); // we intentionally put a market inside here for the margin and swap ledgers
             const marketInfo = this.safeValue (market, 'info', {});
             const settlementCurrencyId = this.safeString (marketInfo, 'settlement_currency');
-            const settlementCurrencyСode = this.safeCurrencyCode (settlementCurrencyId);
-            currency = this.currency (settlementCurrencyСode);
+            const settlementCurrencyCode = this.safeCurrencyCode (settlementCurrencyId);
+            currency = this.currency (settlementCurrencyCode);
             const underlyingId = this.safeString (marketInfo, 'underlying');
             request['underlying'] = underlyingId;
         } else if ((type === 'margin') || (type === 'swap')) {


### PR DESCRIPTION
browser sometime use wrong encoding with Cyrillic script which cause script unable to load.
This will fix the error in some browser.

It's barely noticeable but cause me quite a few hour to debug what cause browser report error message below.
```Uncaught SyntaxError: Missing initializer in const declaration``` 